### PR TITLE
Adding GRAPHQL_URI as its needed by seedDB

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -2,3 +2,4 @@ NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=letmein
 GRAPHQL_LISTEN_PORT=4000
+GRAPHQL_URI=http://localhost:4000


### PR DESCRIPTION
npm run seedDB fails as it needs GRAPHQL_URI to be defined.

https://github.com/grand-stack/grand-stack-starter/blob/ac6be0ee2184bedbfa6a9a4058afd2b9af6011cd/api/src/seed/seed-db.js#L12