### PR TITLE
Add npm script to transpile api code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules/
 /coverage
 
 # production
-/build
+build
 
 # misc
 .DS_Store

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "./node_modules/.bin/nodemon --exec babel-node src/index.js",
+    "build": "babel src -d build; cp .env build; cp src/schema.graphql build",
     "seedDb": "./node_modules/.bin/babel-node src/seed/seed-db.js"
   },
   "author": "William Lyon",


### PR DESCRIPTION
This change makes it easier to transpile the api and run it with node rather than babel-node.