### PR TITLE
Functionality for Now version 2

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/api/now-secrets.json
+++ b/api/now-secrets.json
@@ -1,0 +1,7 @@
+{
+  "@neo4j_uri": "bolt://localhost:7687",
+  "@neo4j_user": "neo4j",
+  "@neo4j_password": "letmein",
+  "@graphql_listen_port": "4000",
+  "@graphql_uri": "http://localhost:4000"
+}

--- a/api/now.json
+++ b/api/now.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.js", "use": "@now/node-server" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.js" }
+  ],
+  "env": {
+    "NEO4J_USER": "@neo4j_user",
+    "NEO4J_PASSWORD": "@neo4j_password",
+    "NEO4J_URI": "@neo4j_uri",
+    "GRAPHQL_LISTEN_PORT": "@graphql_listen_port",
+    "GRAPHQL_URI": "@graphql_uri"
+  }
+}

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -38,11 +38,19 @@ const driver = neo4j.driver(
  * instance into the context object so it is available in the
  * generated resolvers to connect to the database.
  */
+
+// Introspection and playground need to be set to true otherwise you can't use GraphiQL
+// in the Now function, they can be removed for production
 const server = new ApolloServer({
   context: { driver },
-  schema: schema
+  schema: schema,
+  introspection: true,
+  playground: true
 });
 
-server.listen(process.env.GRAPHQL_LISTEN_PORT, "0.0.0.0").then(({ url }) => {
+// Port cannot be hard coded for Now lambda function
+const port = process.env.GRAPHQL_LISTEN_PORT || 4000;
+
+server.listen(port, "0.0.0.0").then(({ url }) => {
   console.log(`GraphQL API ready at ${url}`);
 });


### PR DESCRIPTION
Made changes in index.js that allow now version 2 to build the app with a lambda function. The changes will allow the GraphiQL playground to be used during development. The project structure is set up with a new now.json file and now-secrets.json file which should, of course, be added to the .gitignore file of the project in a real app. Should be able to deploy with just the "now" command. 