### PR TITLE
Added Apollo wrapper to App.test to make initial test pass

### DIFF
--- a/ui-react/src/App.test.js
+++ b/ui-react/src/App.test.js
@@ -1,9 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
+import ApolloClient from "apollo-boost";
+import { ApolloProvider } from "@apollo/react-hooks";
+
+const client = new ApolloClient({
+  uri: process.env.REACT_APP_GRAPHQL_URI
+});
 
 it("renders without crashing", () => {
   const div = document.createElement("div");
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>,
+    div
+  );
   ReactDOM.unmountComponentAtNode(div);
 });


### PR DESCRIPTION
After cloning from master I noticed the App.test fails due to a missing ApolloProvoder wrapper.
Added the wrapper and appropriate imports in order to make the default test pass.