### PR TITLE
Starting react-scripts dev server in CI mode so it runs in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     ports:
       - 3000:3000
     environment:
+      - CI=true
       - REACT_APP_GRAPHQL_URI=/graphql
       - PROXY=http://api:4001/graphql
     links:


### PR DESCRIPTION
This allows the development server that comes with create-react-app to run in docker-compose where no interactive shell is available. Otherwise, the dev server exits immediately.

This addresses issue #60.

To test, pull the latest docker images, or start from a clean slate, and try:

```bash
docker-compose up
```

with and without the `CI=true` environment variable set.