### PR TITLE
Update index.js to include changes to diver config for Neo4j Aura

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -29,7 +29,11 @@ const driver = neo4j.driver(
   neo4j.auth.basic(
     process.env.NEO4J_USER || "neo4j",
     process.env.NEO4J_PASSWORD || "neo4j"
-  )
+  ),
+  // The newest version of the Neo4j driver requires these settings if you're using Aura 
+  {
+  encrypted: process.env.NODE_ENV ? "ENCRYPTION_OFF" : "ENCRYPTION_ON" 
+  }
 );
 
 /*


### PR DESCRIPTION
Upgrading to the newest version of the Neo4j requires a change in the driver config to communicate with Neo4j Aura. Not sure if does the same with the Sandboxes but it's possible.