### PR TITLE
Upgrades vulnerable packages

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -52,12 +52,9 @@
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.12.tgz",
-      "integrity": "sha512-JdC7aBzMUO6SaGH5g6MvIG8TWd+7cU/G9cyjKS/woYVtqyICLamyG21R8SmjiBnd5c1UgPWOxjSIxYBL2ln8Mg==",
-      "requires": {
-        "apollo-env": "^0.9.0"
-      }
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.5.1.tgz",
+      "integrity": "sha512-ZII+/xUFfb9ezDU2gad114+zScxVFMVlZ91f8fGApMzlS1kkqoyLnC4AJaQ1Ya/X+b63I20B4Gd+eCL8QuB4sA=="
     },
     "@apollographql/graphql-playground-html": {
       "version": "1.6.27",
@@ -1636,9 +1633,9 @@
       "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg=="
     },
     "@josephg/resolvable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.0.tgz",
-      "integrity": "sha512-OfTtjoqB2doov5aTJxkyAMK8dXoo7CjCUQSYUEtiY34jbWduOGV7+168tmCT8COMsUEd5DMSFg/0iAOPCBTNAQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz",
+      "integrity": "sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg=="
     },
     "@manypkg/find-root": {
       "version": "1.1.0",
@@ -1851,31 +1848,31 @@
       "integrity": "sha512-orOKSsIVUMsAbKgbSX2ST3FwQt9pxinHVCAIAVl4SmmTxmki2Gu+cGqobMD3eYwDV5FV0YNtaXyxnvE9pLrKTw=="
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "@types/connect": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
-      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-P1bffQfhD3O4LW0ioENXUhZ9OIa0Zn+P7M+pWgkCKaT53wVLSq0mrKksCID/FGHpFhRSxRGhgrQmfhRuzwtKdg=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ=="
     },
     "@types/cookies": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.6.tgz",
-      "integrity": "sha512-FK4U5Qyn7/Sc5ih233OuHO0qAkOpEcD/eG6584yEiLKizTFRny86qHLe/rej3HFQrkBuUjF4whFliAdODbVN/w==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
+      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -1889,9 +1886,9 @@
       "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
     },
     "@types/express": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
-      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.18",
@@ -1900,9 +1897,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
-      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1923,9 +1920,9 @@
       "integrity": "sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ=="
     },
     "@types/http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q=="
     },
     "@types/keygrip": {
       "version": "1.0.2",
@@ -1933,9 +1930,9 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.1.tgz",
-      "integrity": "sha512-Qbno7FWom9nNqu0yHZ6A0+RWt4mrYBhw3wpBAQ3+IuzGcLlfeYkzZrnMq5wsxulN2np8M4KKeUpTodsOsSad5Q==",
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
+      "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -1971,18 +1968,9 @@
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "@types/node": {
-      "version": "14.14.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
-    },
-    "@types/node-fetch": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
-      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
+      "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1990,14 +1978,14 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
     },
     "@types/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/semver": {
       "version": "6.2.2",
@@ -2005,18 +1993,18 @@
       "integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ=="
     },
     "@types/serve-static": {
-      "version": "1.13.9",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
-      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "@types/ws": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-ISCK1iFnR+jYv7+jLNX0wDqesZ/5RAeY3wUx6QaphmocphU61h+b+PHjS18TF4WIPTu/MMzxIq2PHr32o2TS5Q==",
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "requires": {
         "@types/node": "*"
       }
@@ -2134,63 +2122,61 @@
       }
     },
     "apollo-cache-control": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.12.0.tgz",
-      "integrity": "sha512-kClF5rfAm159Nboul1LxA+l58Tjz0M8L1GUknEMpZt0UHhILLAn3BfcG3ToX4TbNoR9M57kKMUcbPWLdy3Up7w==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.14.0.tgz",
+      "integrity": "sha512-qN4BCq90egQrgNnTRMUHikLZZAprf3gbm8rC5Vwmc6ZdLolQ7bFsa769Hqi6Tq/lS31KLsXBLTOsRbfPHph12w==",
       "requires": {
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-plugin-base": "^0.11.0"
+        "apollo-server-env": "^3.1.0",
+        "apollo-server-plugin-base": "^0.13.0"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-datasource": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.8.0.tgz",
-      "integrity": "sha512-gXgsGVLuejLc138z/2jUjPAzadDQxWbcLJyBgaQsg5BaXJNkv5uW/NjiSPk00cK51hyZrb0Xx8a+L+wPk2qIBA==",
-      "requires": {
-        "apollo-server-caching": "^0.6.0",
-        "apollo-server-env": "^3.0.0"
-      }
-    },
-    "apollo-env": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.9.0.tgz",
-      "integrity": "sha512-oMSaFiCYEULXTv1sLhuPpAg0SykJNzEu5QWvCw0844yq14MyETXFERmAYD9b8nNjQLAdpjbbkBGKTWcw5wgd5Q==",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.9.0.tgz",
+      "integrity": "sha512-y8H99NExU1Sk4TvcaUxTdzfq2SZo6uSj5dyh75XSQvbpH6gdAXIW9MaBcvlNC7n0cVPsidHmOcHOWxJ/pTXGjA==",
       "requires": {
-        "@types/node-fetch": "2.5.8",
-        "core-js": "^3.0.1",
-        "node-fetch": "^2.2.0",
-        "sha.js": "^2.4.11"
+        "apollo-server-caching": "^0.7.0",
+        "apollo-server-env": "^3.1.0"
+      },
+      "dependencies": {
+        "apollo-server-caching": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
+          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-graphql": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.6.1.tgz",
-      "integrity": "sha512-ZRXAV+k+hboCVS+FW86FW/QgnDR7gm/xMUwJPGXEbV53OLGuQQdIT0NCYK7AzzVkCfsbb7NJ3mmEclkZY9uuxQ==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.9.3.tgz",
+      "integrity": "sha512-rcAl2E841Iko4kSzj4Pt3PRBitmyq1MvoEmpl04TQSpGnoVgl1E/ZXuLBYxMTSnEAm7umn2IsoY+c6Ll9U/10A==",
       "requires": {
-        "apollo-env": "^0.6.6",
-        "lodash.sortby": "^4.7.0"
-      },
-      "dependencies": {
-        "@types/node-fetch": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-          "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-          "requires": {
-            "@types/node": "*",
-            "form-data": "^3.0.0"
-          }
-        },
-        "apollo-env": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
-          "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
-          "requires": {
-            "@types/node-fetch": "2.5.7",
-            "core-js": "^3.0.1",
-            "node-fetch": "^2.2.0",
-            "sha.js": "^2.4.11"
-          }
-        }
+        "core-js-pure": "^3.10.2",
+        "lodash.sortby": "^4.7.0",
+        "sha.js": "^2.4.11"
       }
     },
     "apollo-link": {
@@ -2244,36 +2230,97 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.23.0.tgz",
-      "integrity": "sha512-3/a4LPgRADc8CdT/nRh7W0CAqQv3Q4DJvakWQgKqGSqDEb/0u4IBynYjlQKuPBi4wwKdeK2Hb1wiQLl+zu4StQ==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.25.2.tgz",
+      "integrity": "sha512-lrohEjde2TmmDTO7FlOs8x5QQbAS0Sd3/t0TaK2TWaodfzi92QAvIsq321Mol6p6oEqmjm8POIDHW1EuJd7XMA==",
       "requires": {
-        "@apollographql/apollo-tools": "^0.4.3",
+        "@apollographql/apollo-tools": "^0.5.0",
         "@apollographql/graphql-playground-html": "1.6.27",
         "@apollographql/graphql-upload-8-fork": "^8.1.3",
         "@josephg/resolvable": "^1.0.0",
         "@types/ws": "^7.0.0",
-        "apollo-cache-control": "^0.12.0",
-        "apollo-datasource": "^0.8.0",
-        "apollo-graphql": "^0.6.0",
-        "apollo-reporting-protobuf": "^0.6.2",
-        "apollo-server-caching": "^0.6.0",
-        "apollo-server-env": "^3.0.0",
+        "apollo-cache-control": "^0.14.0",
+        "apollo-datasource": "^0.9.0",
+        "apollo-graphql": "^0.9.0",
+        "apollo-reporting-protobuf": "^0.8.0",
+        "apollo-server-caching": "^0.7.0",
+        "apollo-server-env": "^3.1.0",
         "apollo-server-errors": "^2.5.0",
-        "apollo-server-plugin-base": "^0.11.0",
-        "apollo-server-types": "^0.7.0",
-        "apollo-tracing": "^0.13.0",
+        "apollo-server-plugin-base": "^0.13.0",
+        "apollo-server-types": "^0.9.0",
+        "apollo-tracing": "^0.15.0",
         "async-retry": "^1.2.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "^0.13.0",
+        "graphql-extensions": "^0.15.0",
         "graphql-tag": "^2.11.0",
         "graphql-tools": "^4.0.8",
         "loglevel": "^1.6.7",
         "lru-cache": "^6.0.0",
         "sha.js": "^2.4.11",
-        "subscriptions-transport-ws": "^0.9.11",
-        "uuid": "^8.0.0",
-        "ws": "^6.0.0"
+        "subscriptions-transport-ws": "^0.9.19",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "@apollo/protobufjs": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "@types/node": "^10.1.0",
+            "long": "^4.0.0"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "apollo-reporting-protobuf": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
+          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
+          "requires": {
+            "@apollo/protobufjs": "1.2.2"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
+          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
+          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.8.0",
+            "apollo-server-caching": "^0.7.0",
+            "apollo-server-env": "^3.1.0"
+          }
+        }
       }
     },
     "apollo-server-env": {
@@ -2291,27 +2338,100 @@
       "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA=="
     },
     "apollo-server-express": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.23.0.tgz",
-      "integrity": "sha512-tzil7c51ODH0rT1Bc5VMksdWzHrYGavdLtnDz4M0ePiTm18Gc81HD7X/4DPczorerEpfwwkf2YlADtPQfRSxlw==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.25.2.tgz",
+      "integrity": "sha512-A2gF2e85vvDugPlajbhr0A14cDFDIGX0mteNOJ8P3Z3cIM0D4hwrWxJidI+SzobefDIyIHu1dynFedJVhV0euQ==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.27",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
         "@types/cors": "2.8.10",
-        "@types/express": "4.17.11",
-        "@types/express-serve-static-core": "4.17.19",
+        "@types/express": "^4.17.12",
+        "@types/express-serve-static-core": "^4.17.21",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.23.0",
-        "apollo-server-types": "^0.7.0",
+        "apollo-server-core": "^2.25.2",
+        "apollo-server-types": "^0.9.0",
         "body-parser": "^1.18.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.8",
         "parseurl": "^1.3.2",
-        "subscriptions-transport-ws": "^0.9.16",
+        "subscriptions-transport-ws": "^0.9.19",
         "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@apollo/protobufjs": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "@types/node": "^10.1.0",
+            "long": "^4.0.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.60",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+              "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+            }
+          }
+        },
+        "@types/body-parser": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+          "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+          "requires": {
+            "@types/connect": "*",
+            "@types/node": "*"
+          }
+        },
+        "apollo-reporting-protobuf": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
+          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
+          "requires": {
+            "@apollo/protobufjs": "1.2.2"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
+          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
+          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.8.0",
+            "apollo-server-caching": "^0.7.0",
+            "apollo-server-env": "^3.1.0"
+          }
+        }
       }
     },
     "apollo-server-lambda": {
@@ -2328,11 +2448,73 @@
       }
     },
     "apollo-server-plugin-base": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.11.0.tgz",
-      "integrity": "sha512-Du68x0XCyQ6EWlgoL9Z+1s8fJfXgY131QbKP7ao617StQPzwB0aGCwxBDfcMt1A75VXf4TkvV1rdUH5YeJFlhQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.13.0.tgz",
+      "integrity": "sha512-L3TMmq2YE6BU6I4Tmgygmd0W55L+6XfD9137k+cWEBFu50vRY4Re+d+fL5WuPkk5xSPKd/PIaqzidu5V/zz8Kg==",
       "requires": {
-        "apollo-server-types": "^0.7.0"
+        "apollo-server-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@apollo/protobufjs": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "@types/node": "^10.1.0",
+            "long": "^4.0.0"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "apollo-reporting-protobuf": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
+          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
+          "requires": {
+            "@apollo/protobufjs": "1.2.2"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
+          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
+          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.8.0",
+            "apollo-server-caching": "^0.7.0",
+            "apollo-server-env": "^3.1.0"
+          }
+        }
       }
     },
     "apollo-server-types": {
@@ -2346,12 +2528,23 @@
       }
     },
     "apollo-tracing": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.13.0.tgz",
-      "integrity": "sha512-28z4T+XfLQ6t696usU0nTFDxVN8BfF3o74d2p/zsT4eu1OuoyoDOEmVJqdInmVRpyTJK0tDEOjkIuDJJHZftog==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.15.0.tgz",
+      "integrity": "sha512-UP0fztFvaZPHDhIB/J+qGuy6hWO4If069MGC98qVs0I8FICIGu4/8ykpX3X3K6RtaQ56EDAWKykCxFv4ScxMeA==",
       "requires": {
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-plugin-base": "^0.11.0"
+        "apollo-server-env": "^3.1.0",
+        "apollo-server-plugin-base": "^0.13.0"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-utilities": {
@@ -2447,11 +2640,6 @@
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "dev": true
     },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
-    },
     "async-retry": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
@@ -2459,11 +2647,6 @@
       "requires": {
         "retry": "0.12.0"
       }
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -3112,14 +3295,6 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -3245,7 +3420,8 @@
     "core-js": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
-      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.11.0",
@@ -3268,8 +3444,7 @@
     "core-js-pure": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.11.0.tgz",
-      "integrity": "sha512-PxEiQGjzC+5qbvE7ZIs5Zn6BynNeZO9zHhrrWmkRff2SZLq0CE/H5LuZOJHhmOQ8L38+eMzEHAmPYWrUtDfuDQ==",
-      "dev": true
+      "integrity": "sha512-PxEiQGjzC+5qbvE7ZIs5Zn6BynNeZO9zHhrrWmkRff2SZLq0CE/H5LuZOJHhmOQ8L38+eMzEHAmPYWrUtDfuDQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3471,11 +3646,6 @@
           }
         }
       }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -4213,16 +4383,6 @@
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
-    "form-data": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4422,13 +4582,75 @@
       }
     },
     "graphql-extensions": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.13.0.tgz",
-      "integrity": "sha512-Bb7E97nvfX4gtrIdZ/i5YFlqOd6MGzrw8ED+t4wQVraYje6NQ+8P8MHMOV2WZLfbW8zsNTx8NdnnlbsdH5siag==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.15.0.tgz",
+      "integrity": "sha512-bVddVO8YFJPwuACn+3pgmrEg6I8iBuYLuwvxiE+lcQQ7POotVZxm2rgGw0PvVYmWWf3DT7nTVDZ5ROh/ALp8mA==",
       "requires": {
-        "@apollographql/apollo-tools": "^0.4.3",
-        "apollo-server-env": "^3.0.0",
-        "apollo-server-types": "^0.7.0"
+        "@apollographql/apollo-tools": "^0.5.0",
+        "apollo-server-env": "^3.1.0",
+        "apollo-server-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@apollo/protobufjs": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.2.tgz",
+          "integrity": "sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.0",
+            "@types/node": "^10.1.0",
+            "long": "^4.0.0"
+          }
+        },
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "apollo-reporting-protobuf": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.8.0.tgz",
+          "integrity": "sha512-B3XmnkH6Y458iV6OsA7AhfwvTgeZnFq9nPVjbxmLKnvfkEl8hYADtz724uPa0WeBiD7DSFcnLtqg9yGmCkBohg==",
+          "requires": {
+            "@apollo/protobufjs": "1.2.2"
+          }
+        },
+        "apollo-server-caching": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz",
+          "integrity": "sha512-MsVCuf/2FxuTFVhGLK13B+TZH9tBd2qkyoXKKILIiGcZ5CDUEBO14vIV63aNkMkS1xxvK2U4wBcuuNj/VH2Mkw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "apollo-server-env": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-3.1.0.tgz",
+          "integrity": "sha512-iGdZgEOAuVop3vb0F2J3+kaBVi4caMoxefHosxmgzAbbSpvWehB8Y1QiSyyMeouYC38XNVk5wnZl+jdGSsWsIQ==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "util.promisify": "^1.0.0"
+          }
+        },
+        "apollo-server-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-types/-/apollo-server-types-0.9.0.tgz",
+          "integrity": "sha512-qk9tg4Imwpk732JJHBkhW0jzfG0nFsLqK2DY6UhvJf7jLnRePYsPxWfPiNkxni27pLE2tiNlCwoDFSeWqpZyBg==",
+          "requires": {
+            "apollo-reporting-protobuf": "^0.8.0",
+            "apollo-server-caching": "^0.7.0",
+            "apollo-server-env": "^3.1.0"
+          }
+        }
       }
     },
     "graphql-parse-resolve-info": {
@@ -7022,29 +7244,21 @@
       "dev": true
     },
     "subscriptions-transport-ws": {
-      "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz",
-      "integrity": "sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==",
+      "version": "0.9.19",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
+      "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
         "iterall": "^1.2.1",
         "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0"
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
       },
       "dependencies": {
         "symbol-observable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
           "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        },
-        "ws": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-          "requires": {
-            "async-limiter": "~1.0.0"
-          }
         }
       }
     },
@@ -7151,9 +7365,9 @@
       }
     },
     "trim-newlines": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
-      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "ts-invariant": {
       "version": "0.7.3",
@@ -7697,12 +7911,9 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/web-react/package-lock.json
+++ b/web-react/package-lock.json
@@ -3679,15 +3679,37 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+      "integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001219",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30001248",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
+          "integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
+        },
+        "colorette": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+          "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.791",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.791.tgz",
+          "integrity": "sha512-Tdx7w1fZpeWOOBluK+kXTAKCXyc79K65RB6Zp0+sPSZZhDjXlrxfGlXrlMGVVQUrKCyEZFQs1UBBLNz5IdbF0g=="
+        },
+        "node-releases": {
+          "version": "1.1.73",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+          "integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
+        }
       }
     },
     "bser": {
@@ -5080,9 +5102,9 @@
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "requires": {
         "ip": "^1.1.0",
         "safe-buffer": "^5.0.1"
@@ -6956,9 +6978,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -7194,9 +7216,9 @@
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -9790,9 +9812,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -10268,11 +10290,6 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
-    },
-    "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12038,19 +12055,26 @@
       },
       "dependencies": {
         "postcss": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.4.tgz",
-          "integrity": "sha512-kRFftRoExRVXZlwUuay9iC824qmXPcQQVzAjbCCgjpXnkdMCJYBu2gTwAaFBzv8ewND6O8xFb3aELmEkh9zTzg==",
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
           "requires": {
-            "colorette": "^1.2.1",
-            "nanoid": "^3.1.20",
-            "source-map": "^0.6.1"
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          },
+          "dependencies": {
+            "colorette": {
+              "version": "1.2.2",
+              "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+              "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+            },
+            "nanoid": {
+              "version": "3.1.23",
+              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+              "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+            }
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -14015,6 +14039,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -15179,9 +15208,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
-      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -16764,9 +16793,9 @@
       }
     },
     "ws": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",


### PR DESCRIPTION
My initial run of `npm install` reported nearly 6000 vulnetabilities.

This PR is just the result of running `npm audit fix` on the `api` & `web-react` elements.

Happy to submit another PR for the other component, if this is acceptable.